### PR TITLE
fix:if members,teams or projects are deleted related data is updated

### DIFF
--- a/.sqlx/query-87db819879ebe2b598c6b4f060cb0ab00a49849af9bbb6d2823f6f46057340db.json
+++ b/.sqlx/query-87db819879ebe2b598c6b4f060cb0ab00a49849af9bbb6d2823f6f46057340db.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                DELETE FROM teams_by_projects\n                WHERE project_id = $1\n                ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "87db819879ebe2b598c6b4f060cb0ab00a49849af9bbb6d2823f6f46057340db"
+}

--- a/.sqlx/query-8f6e96233ebe68be12e9a93659ad056ac577e21301957111df24a81c57f2dfed.json
+++ b/.sqlx/query-8f6e96233ebe68be12e9a93659ad056ac577e21301957111df24a81c57f2dfed.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                DELETE FROM teams_by_projects\n                WHERE team_id = $1\n                ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "8f6e96233ebe68be12e9a93659ad056ac577e21301957111df24a81c57f2dfed"
+}

--- a/.sqlx/query-e04ac178735886f68a78523d4f0e504c46cb1b75304496d65f3d631a87904a0d.json
+++ b/.sqlx/query-e04ac178735886f68a78523d4f0e504c46cb1b75304496d65f3d631a87904a0d.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE projects\n            SET\n                lead_id = NULL\n            WHERE lead_id = $1\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "e04ac178735886f68a78523d4f0e504c46cb1b75304496d65f3d631a87904a0d"
+}

--- a/.sqlx/query-e2fcd1cb0369e92403ab7fdd93f576fcd849e09177da0059b12822f3b53b7b77.json
+++ b/.sqlx/query-e2fcd1cb0369e92403ab7fdd93f576fcd849e09177da0059b12822f3b53b7b77.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                DELETE FROM members_by_teams\n                WHERE member_id = $1\n                ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "e2fcd1cb0369e92403ab7fdd93f576fcd849e09177da0059b12822f3b53b7b77"
+}

--- a/.sqlx/query-ef44d88468467a08c4ebee93a50f92b7bc7846dd7a4200c7a42ee5d2e6ebfa34.json
+++ b/.sqlx/query-ef44d88468467a08c4ebee93a50f92b7bc7846dd7a4200c7a42ee5d2e6ebfa34.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                DELETE FROM members_by_projects\n                WHERE member_id = $1\n                ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "ef44d88468467a08c4ebee93a50f92b7bc7846dd7a4200c7a42ee5d2e6ebfa34"
+}

--- a/crates/plexo-sdk/src/resources/members/operations.rs
+++ b/crates/plexo-sdk/src/resources/members/operations.rs
@@ -340,6 +340,38 @@ impl MemberCrudOperations for SDKEngine {
         .execute(&mut *tx)
         .await?;
 
+        sqlx::query!(
+            r#"
+            UPDATE projects
+            SET
+                lead_id = NULL
+            WHERE lead_id = $1
+            "#,
+            id,
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query!(
+            r#"
+                DELETE FROM members_by_projects
+                WHERE member_id = $1
+                "#,
+            id,
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query!(
+            r#"
+                DELETE FROM members_by_teams
+                WHERE member_id = $1
+                "#,
+            id,
+        )
+        .execute(&mut *tx)
+        .await?;
+
         let member_info = sqlx::query!(
             r#"
             DELETE FROM members WHERE id = $1

--- a/crates/plexo-sdk/src/resources/projects/operations.rs
+++ b/crates/plexo-sdk/src/resources/projects/operations.rs
@@ -424,6 +424,16 @@ impl ProjectCrudOperations for SDKEngine {
         .execute(&mut *tx)
         .await?;
 
+        sqlx::query!(
+            r#"
+                DELETE FROM teams_by_projects
+                WHERE project_id = $1
+                "#,
+            id,
+        )
+        .execute(&mut *tx)
+        .await?;
+
         let project_info = sqlx::query!(
             r#"
             DELETE FROM projects WHERE id = $1


### PR DESCRIPTION
PLE-268: Al eliminar un miembro que pertenece a un project o team, genera error en ambos queries
PLE-269: Al eliminar un proyecto o team que se encuentra asignado a un proyecto/team se genera un error en los queries

Nota: Además agregué actualizacion de leader_id en task resource